### PR TITLE
add operational notes

### DIFF
--- a/ops/README.md
+++ b/ops/README.md
@@ -1,0 +1,1 @@
+# Operational notes

--- a/ops/post-transfer.md
+++ b/ops/post-transfer.md
@@ -1,0 +1,127 @@
+# Post transfer TODO list
+
+## Travis CI
+
+Browse to https://travis-ci.org/rust-embedded/repo-name/settings and make sure that "Build pushed
+pull requests" is enabled.
+
+
+## Source
+
+Push a commit to `master` that does the following:
+
+- Creates `.github/CODEOWNERS` with the following contents:
+
+``` text
+* rust-embedded/team-name collaborator-name another-collaborator
+```
+
+- Adds a copy of [`CODE_OF_CONDUCT.md`][CoC]. Don't forget to adjust the team name and associated
+  link accordingly.
+
+[CoC]: https://github.com/rust-embedded/cortex-m/blob/master/CODE_OF_CONDUCT.md
+
+- Modifies `.travis.yml` to:
+  - Allow builds on these three branches. `staging` and `trying` are required by bors. We include
+    `master` to have builds on pushed PRs.
+
+``` yaml
+branches:
+  only:
+    - master
+    - staging
+    - trying
+```
+
+  - Prevent builds on changes to master. This is to prevent testing a PR *twice*: one build is
+    required to land the PR, but when the changes are merged into master we want to avoid that
+    second build.
+
+``` yaml
+matrix:
+  include:
+    - env: TARGET=thumbv6m-none-eabi
+      # add this `if` ...
+      if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
+
+    - env: TARGET=thumbv7m-none-eabi
+      # ... to all the elements of the build matrix
+      if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
+```
+
+- Mention the Code of Conduct and which team owns this repository in the README
+
+``` markdown
+# project-name
+
+> description of the project
+
+<!-- TODO add this -->
+
+This project is developed and maintained by the [Cortex-M team][team].
+
+<!-- ... omitting stuff in between ... -->
+
+<!-- TODO add this -->
+
+## Code of Conduct
+
+Contribution to this crate is organized under the terms of the [Rust Code of
+Conduct][CoC], the maintainer of this crate, the [Cortex-M team][team], promises
+to intervene to uphold that code of conduct.
+
+[CoC]: CODE_OF_CONDUCT.md
+[team]: https://github.com/rust-embedded/wg#the-cortex-m-team
+```
+
+- If the repository uses CI, configure bors. Add a `.github/bors.toml` file with these contents:
+
+``` toml
+block_labels = ["needs-decision"]
+delete_merged_branches = true
+required_approvals = 1
+status = ["continuous-integration/travis-ci/push"]
+```
+
+## Bors
+
+If the repository uses CI, update bors settings.
+
+- Browse to https://app.bors.tech/repositories, click on rust-embedded/repo-name and then switch
+  to the "Settings" tab.
+
+- Synchronize both "Reviewers" and "Members" to people with "Push" (write) access to the
+    repository.
+
+## Repository
+
+Update the repository settings.
+
+- Browse to https://github.com/rust-embedded/repo-name/settings and switch to the "Collaborators &
+  teams" tab.
+
+- Add the team that will oversee the project and give them "Admin" permissions.
+
+- The previous owner and old collaborators should have "Write" permissions.
+
+- Now switch to the "Branches" tab and add a branch protection rule for `master` with the
+  following settings:
+
+  - [x] Require pull requests reviews before merging
+    - [x] Dismiss stale pull request approvals when new commits are pushed
+    - [x] Require review from Code Owners
+
+  - [x] Require status checks to pass before merging (NOTE omit if not using CI)
+    - [x] bors (NOTE if bors doesn't appear here you will have to make a dummy PR, `bors r+` it
+      and then close it. This will make bors visible in this list)
+
+  - [x] Include administrators
+
+## crates.io
+
+If applicable, add new owners to crates.io. Have the current owner add the team that's receiving
+the crate as a team owner.
+
+```
+$ cargo owner --add github:rust-embedded:team-name
+```

--- a/ops/publish.md
+++ b/ops/publish.md
@@ -1,0 +1,61 @@
+# Publishing workflow
+
+## Pull request
+
+Open a PR that:
+
+- Updates `CHANGELOG.md` to include the new version. We use the [Keep a Changelog] format. Don't
+  forget to include the version link at the bottom. Example below:
+
+[Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
+
+``` markdown
+## [Unreleased]
+
+<!-- TODO Move everything in this section to the new version section below -->
+
+<!-- TODO Add this new section -->
+## [v0.5.3] - 2018-08-02
+
+### Added
+
+- Some stuff.
+
+### Fixed
+
+- Some stuff.
+
+### Removed
+
+- Some stuff.
+
+<!-- NOTE This was already here -->
+## [v0.5.2] - 2018-05-18
+
+<!-- ... omitting stuff in between ... -->
+
+<!-- TODO Change the start of the range -->
+[Unreleased]: https://github.com/rust-embedded/cortex-m/compare/v0.5.3...HEAD
+
+<!-- TODO Add this new link -->
+[v0.5.3]: https://github.com/rust-embedded/cortex-m/compare/v0.5.2...v0.5.3
+
+<!-- NOTE This was already here -->
+[v0.5.2]: https://github.com/rust-embedded/cortex-m/compare/v0.5.1...v0.5.2
+```
+
+- Bumps the crate version in `Cargo.toml`.
+
+## `cargo publish`
+
+After the PR has been merged, run `cargo publish` locally
+
+## Tag
+
+Afterwards, create an annotated tag and push it
+
+``` console
+$ git tag -a 'v0.5.3' -m 'v0.5.3'
+
+$ git push origin v0.5.3
+```

--- a/ops/review.md
+++ b/ops/review.md
@@ -1,0 +1,24 @@
+# Reviewer handbook
+
+These apply to both team members and collaborators.
+
+We use https://bors.tech in all our repositories. Bors commands are documented in
+https://bors.tech/documentation/
+
+All PRs must be approved using [GitHub reviews] before you can send the PR to bors.
+
+[GitHub reviews]: https://help.github.com/articles/approving-a-pull-request-with-required-reviews/
+
+Most PRs can be approved by a single team member or collaborator, but PRs labeled `needs-decision`
+need to be approved by the whole team (see [voting majority]) before they are sent to bors.
+
+- Apply the `needs-decision` label to all PRs that include breaking changes and / or major changes
+  that have not been previously discussed and approved.
+
+- bors will ignore `r+` commands on PRs that have the `needs-decision` label.
+
+- Remove the `needs-decision` label after voting majority has been achieved.
+
+- At this point you can review the PR and send it to bors.
+
+[voting majority]: https://github.com/rust-embedded/wg/blob/master/rfcs/0136-teams.md#voting-majority


### PR DESCRIPTION
As suggested in https://github.com/rust-embedded/wg/issues/148#issuecomment-411246711.

I'm putting them in a PR for now regardless of wherever we decide to put them in the end because that seems like a better place than in my head :-).

cc @jamesmunns @adamgreig 