### PR TITLE
add links to README; remove thejpster from CODEOWNERS ..

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @rust-embedded/all @dylanmckay @jcsoo @thejpster
+* @rust-embedded/all @dylanmckay @jcsoo

--- a/README.md
+++ b/README.md
@@ -231,9 +231,11 @@ irc.mozilla.org).
 [@jcsoo]: https://github.com/jcsoo
 [@korken89]: https://github.com/korken89
 [@nastevens]: https://github.com/nastevens
+[@nerdyvaishali]: https://github.com/nerdyvaishali
 [@pftbest]: https://github.com/pftbest
 [@posborne]: https://github.com/posborne
 [@ryankurte]: https://github.com/ryankurte
+[@sekineh]: https://github.com/sekineh
 [@thejpster]: https://github.com/thejpster
 [@therealprof]: https://github.com/therealprof
 


### PR DESCRIPTION
he's already included in the list of owner as a member of the rust-embedded/all team

Forgot to add links to the usernames added in #174

r? @rust-embedded/all