### PR TITLE
Update Embedded Book for mdbook 0.2.0

### DIFF
--- a/books/embedded-rust-book/src/intro/hardware.md
+++ b/books/embedded-rust-book/src/intro/hardware.md
@@ -12,7 +12,7 @@ Let's get familiar with the hardware we'll be working with.
 ## STM32F3DISCOVERY (the "F3")
 
 <p align="center">
-<img title="F3" src="assets/f3.jpg">
+<img title="F3" src="../assets/f3.jpg">
 </p>
 
 We'll refer to this board as "F3" throughout this book.


### PR DESCRIPTION
mdbook 0.2.0's has a breaking change such that links are relative to the file they are in instead of the top level of the book. Luckily, this is your only link like that. So once you accept this PR you can build with mdbook 0.2.0 which is what we're trying to switch to for the the bookshelf.