### PR TITLE
add e-mail addresses for the teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,16 @@ most of them are members of one of the teams listed above.
 
 ### Contact
 
+Each team can be privately contacted via the following e-mail addresses:
+
+- cortex-m@teams.rust-embedded.org
+- embedded-linux@teams.rust-embedded.org
+- hal@teams.rust-embedded.org
+- msp430@teams.rust-embedded.org
+- riscv@teams.rust-embedded.org
+- resources@teams.rust-embedded.org
+- tools@teams.rust-embedded.org
+
 You can usually find the members of the embedded WG on the #rust-embedded channel (server:
 irc.mozilla.org).
 

--- a/README.md
+++ b/README.md
@@ -356,12 +356,14 @@ most of them are members of one of the teams listed above.
 Each team can be privately contacted via the following e-mail addresses:
 
 - cortex-m@teams.rust-embedded.org
+- cortex-r@teams.rust-embedded.org
 - embedded-linux@teams.rust-embedded.org
 - hal@teams.rust-embedded.org
-- msp430@teams.rust-embedded.org
-- riscv@teams.rust-embedded.org
+- infrastructure@teams.rust-embedded.org
 - resources@teams.rust-embedded.org
 - tools@teams.rust-embedded.org
+<!-- - msp430@teams.rust-embedded.org -->
+<!-- - riscv@teams.rust-embedded.org -->
 
 You can usually find the members of the embedded WG on the #rust-embedded channel (server:
 irc.mozilla.org).


### PR DESCRIPTION
This a proposal to give each team an e-mail address. As discussed in the last
meeting we'll be using the `team-name@teams.rust-embedded.org` format for the
e-mail addresses.

This proposal (PR) needs at least 10 votes (approvals) from @rust-embedded/all
to be accepted. After the proposal has been accepted we'll proceed to implement
it.

@rust-embedded/all please vote on this proposal using [pull request reviews].
Or if you have a concern leave a comment.

[pull request reviews]: https://help.github.com/articles/about-pull-request-reviews/