### PR TITLE
use logbot to log our IRC channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,11 @@ most of them are members of one of the teams listed above.
 You can usually find the members of the embedded WG on the #rust-embedded channel (server:
 irc.mozilla.org).
 
+Our IRC channel is logged using [logbot] and you can find the logs at
+https://mozilla.logbot.info/rust-embedded
+
+[logbot]: https://mozilla.logbot.info
+
 [@Emilgardis]: https://github.com/Emilgardis
 [@adamgreig]: https://github.com/adamgreig
 [@andre-richter]: https://github.com/andre-richter


### PR DESCRIPTION
This a proposal to log our IRC channel using logbot.

This proposal (PR) needs at least 10 votes (approvals) from @rust-embedded/all
to be accepted. After the proposal has been accepted we'll proceed to implement
it.

@rust-embedded/all please vote on this proposal using [pull request reviews].
Or if you have a concern leave a comment.

[pull request reviews]: https://help.github.com/articles/about-pull-request-reviews/

closes #171