### PR TITLE
[RFC] initial Cortex-R team

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,20 @@ Projects maintained by this team.
 - [`panic-itm`]
 - [`panic-semihosting`]
 
+### The Cortex-R team
+
+The Cortex-R team develops and maintains the core of the Cortex-R crate ecosystem.
+
+#### Members
+
+- [@japaric]
+- [@paoloteti]
+
+#### Projects
+
+It's early days for this team. They don't maintain projects within this
+organization at the moment.
+
 ### The embedded Linux team
 
 The embedded Linux team develops and maintains the core of the embedded Linux crate ecosystem.
@@ -324,6 +338,7 @@ https://mozilla.logbot.info/rust-embedded
 [@korken89]: https://github.com/korken89
 [@nastevens]: https://github.com/nastevens
 [@nerdyvaishali]: https://github.com/nerdyvaishali
+[@paoloteti]: https://github.com/paoloteti
 [@pftbest]: https://github.com/pftbest
 [@posborne]: https://github.com/posborne
 [@ryankurte]: https://github.com/ryankurte


### PR DESCRIPTION
This is a proposal for creating a Cortex-R team.

@paoloteti and I will be the initial members. I know pretty much nothing about
the Cortex-R but will be working with them starting November; @paoloteti is the
real expert here.

The following work has been planed for this team (some of it has been done
already)

- [x] Add more built-in targets to cover existing devices. In
  rust-lang/rust#53679 we went from 1 target to 4. We now have good coverage of
  Cortex R4(F) and R5(F) cores.

- [x] Move to LLD to remove the dependency on a external linker. Done in
  rust-lang/rust#53679.

- [x] Produce `rust-std` components to not depend on tools like Xargo, which
  require nightly. Also done in rust-lang/rust#53679.

- [ ] Create a `cortex-r` crate (\*) akin to the `cortex-m` crate that provides
  a safe API to emit arch-specific instructions and to manipulate system
  registers.

- [ ] Create a `cortex-r-rt` crate (\*) akin to the `cortex-m-rt` crate that
  helps building a minimal `no_std` binary.

- [ ] See if we can generate register APIs from the XML files that vendors like
  TI ship with their IDEs.

(\*) Initial work in this area: https://github.com/paoloteti/ti-hercules-bsp

@rust-embedded/all please vote on this proposal using [GitHub reviews][approve].
This proposal needs at least 11 approvals to land (/all has 21 members atm).

[approve]: https://help.github.com/articles/approving-a-pull-request-with-required-reviews/
