### PR TITLE
[RFC] Initial Cortex-A team

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,25 @@ WG.
 [Rust teams]: https://www.rust-lang.org/en-US/team.html
 [voting majority]: https://github.com/rust-lang-nursery/embedded-wg/blob/master/rfcs/0136-teams.md#voting-majority
 
+
+### The Cortex-A team
+
+The Cortex-A team develops and maintains the core of the Cortex-A crate ecosystem.
+
+#### Members
+
+- [@andre-richter]
+- [@raw-bin]
+- [@wizofe]
+
+#### Projects
+
+Projects maintained by this team.
+
+- `cortex-a`
+- `register-rs`
+- `rust-raspi3-tutorial`
+
 ### The Cortex-M team
 
 The Cortex-M team develops and maintains the core of the Cortex-M crate ecosystem.
@@ -341,10 +360,12 @@ https://mozilla.logbot.info/rust-embedded
 [@paoloteti]: https://github.com/paoloteti
 [@pftbest]: https://github.com/pftbest
 [@posborne]: https://github.com/posborne
+[@raw-bin]: https://github.com/raw-bin
 [@ryankurte]: https://github.com/ryankurte
 [@sekineh]: https://github.com/sekineh
 [@thejpster]: https://github.com/thejpster
 [@therealprof]: https://github.com/therealprof
+[@wizofe]: https://github.com/wizofe
 
 [@rustembedded twitter]: https://twitter.com/rustembedded
 [Awesome embedded Rust]: https://github.com/rust-embedded/awesome-embedded-rust

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ The Cortex-A team develops and maintains the core of the Cortex-A crate ecosyste
 #### Members
 
 - [@andre-richter]
+- [@parched]
 - [@raw-bin]
 - [@wizofe]
 
@@ -141,9 +142,7 @@ The Cortex-A team develops and maintains the core of the Cortex-A crate ecosyste
 
 Projects maintained by this team.
 
-- `cortex-a`
-- `register-rs`
-- `rust-raspi3-tutorial`
+- To be updated soon.
 
 ### The Cortex-M team
 
@@ -357,6 +356,7 @@ https://mozilla.logbot.info/rust-embedded
 [@korken89]: https://github.com/korken89
 [@nastevens]: https://github.com/nastevens
 [@nerdyvaishali]: https://github.com/nerdyvaishali
+[@parched]: https://github.com/parched
 [@paoloteti]: https://github.com/paoloteti
 [@pftbest]: https://github.com/pftbest
 [@posborne]: https://github.com/posborne


### PR DESCRIPTION
This is a proposal for creating a Cortex-A team.

This is based on and will close issue #182. Please refrain from approving until I removed the [DRAFT] from the title and every proposed member has his points on the agenda.

@raw-bin, @wizofe and me will be the initial members.

The following work is planned for this team:

### Maintain a set of ecosystem crates under the embedded WG

- [ ] Write a tool that generates accessors for the ARM System Register XML.
- [ ] Move [cortex-a](https://github.com/andre-richter/cortex-a) to the WG and keep extending/completing it.
    - [ ] If feasible, feed the XML accessors into the crate.
    - [ ] Add ready-to-use idioms for bare-metal use cases.
        - [ ] MMU idioms
        - [ ] GIC idioms
        - [ ] ...? 
- [ ] Move [register-rs](https://github.com/rust-osdev/register-rs) to the WG. CC @phil-opp for sign-off.
- [ ] Discuss if something the likes of `cortex-m-rt` is feasible for cortex-a.

### Provide resources for learning

- [ ] Move [rust-raspi3-tutorial](https://github.com/andre-richter/rust-raspi3-tutorial) to the WG

### Make it possible to build AArch64 kernels / programs on stable.

- [ ] Add a `rust-std` component for `aarch64-unknown-none`
- [ ] Differentiate into further aarch64 targets, e.g. a non-fp version of `aarch64-unknown-none`, and add them as well.

### Stabilization

- [ ] Push for a stable core::arch::arm module (see #63) to make the `cortex-a` crate (see its asm module) work on stable w/o depending on GCC.

------------------

@raw-bin and @wizofe, kindly let me know your agenda points and I will edit them into this comment.
I understand your Redox work will most probably be a part of it, but I want to leave it to you guys to describe it.

Once we are set, I will remove the [DRAFT] and open this for members to approve.

@jamesmunns I tend to agree to your thought about having a microprocessor group. However, I think that cortex-a alone is such a complex architecture, it can easily keep the initial three of us busy for years to come.
I would argue that we would need separate teams for PPC, RISC-V and the likes.