### PR TITLE
Transfer gpio-cdev repo ownership to embedded Linux team

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ The embedded Linux team develops and maintains the core of the embedded Linux cr
 
 Projects maintained by the embedded Linux team
 
+- [`gpio-cdev`]
 - [`gpio-utils`]
 - [`i2cdev`]
 - [`linux-embedded-hal`]
@@ -376,6 +377,7 @@ https://mozilla.logbot.info/rust-embedded
 [`cortex-m`]: https://github.com/rust-embedded/cortex-m
 [`cross`]: https://github.com/rust-embedded/cross
 [`embedded-hal`]: https://github.com/rust-embedded/embedded-hal
+[`gpio-cdev`]: https://github.com/rust-embedded/gpio-cdev
 [`gpio-utils`]: https://github.com/rust-embedded/gpio-utils
 [`i2cdev`]: https://github.com/rust-embedded/rust-i2cdev
 [`itm`]: https://github.com/rust-embedded/itm


### PR DESCRIPTION
Currently hosted at https://github.com/posborne/rust-gpio-cdev.  The repo would be migrated to rust-embedded/gpio-cdev.

[`gpio-cdev`](https://crates.io/crates/gpio-cdev) is a new crate for interacting with GPIOs in Linux using the character device API (the sysfs interface is now deprecated and will be going away in future kernels [2020]).  Differences from the old API are [covered in the project README](https://github.com/posborne/rust-gpio-cdev#sysfs-gpio-vs-gpio-character-device).  Now that the initial work for the crate is done and an initial version of this crate, I want to transfer ownership over to the working group.

I didn't see a documented process for this kind of transfer, so I'm winging it a bit and using the change to the team ownership as a review checkpoint for the overall inclusion decision.  In this case, several (but not all) of the changes from the [Post Transfer TODO List](https://github.com/rust-embedded/wg/blob/master/ops/post-transfer.md) have already been done on the repo.  The other would be done once moved over -- several of the other Linux repos which have been around for awhile need a refresh along the same lines (many of those date back to when I created this GH org a few years back).

r? @rust-embedded/embedded-linux 

---

Since this crate is very new (0.1 was just published today), review and feedback on the APIs is, of course, greatly appreciated.