### PR TITLE
Rename ops team to infrastructure team

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,9 +227,9 @@ Projects maintained by this team
 - [`msp430-rt`]
 - [`msp430`]
 
-### The ops team
+### The infrastructure team
 
-The ops team manages our domains, DNS records, e-mail aliases, etc.
+The infrastructure team manages our domains, DNS records, e-mail aliases, etc.
 
 #### Members
 


### PR DESCRIPTION
Ambiguity between working group operations and `ops` / `operations` team was raised at the last meeting. This PR renames the `ops` team to the `infrastructure` team to remove that ambiguity, as suggested in https://github.com/rust-embedded/wg/issues/217#issuecomment-425669425.