### PR TITLE
Add register-rs to the project list of new Cortex-A team

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ The Cortex-A team develops and maintains the core of the Cortex-A crate ecosyste
 
 Projects maintained by this team.
 
+- [`register-rs`]
 - To be updated soon.
 
 ### The Cortex-M team
@@ -407,6 +408,7 @@ https://mozilla.logbot.info/rust-embedded
 [`msp430`]: https://github.com/pftbest/msp430
 [`panic-itm`]: https://github.com/rust-embedded/panic-itm
 [`panic-semihosting`]: https://github.com/rust-embedded/panic-semihosting
+[`register-rs`]: https://github.com/rust-embedded/register-rs
 [`riscv-rt`]: https://github.com/riscv-rust/riscv-rt
 [`riscv-rust-quickstart`]: https://github.com/riscv-rust/riscv-rust-quickstart
 [`riscv`]: https://github.com/riscv-rust/riscv


### PR DESCRIPTION
The crate is currently hosted under the rust-osdev organization: https://github.com/rust-osdev/register-rs. Moving it to the WG was part of the recently accepted [RFC for a Cortex-A team](https://github.com/rust-embedded/wg/pull/207#issuecomment-427606754).

This PR follows the process outlined in https://github.com/rust-embedded/wg/blob/master/rfcs/0136-teams.md#adopting-projects.

cc @andre-richter @japaric 