### PR TITLE
Add rust-raspi3-tutorial to the project list of the Cortex-A team

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Projects maintained by this team.
 
 - [`cortex-a`]
 - [`register-rs`]
-- To be updated soon.
+- [`rust-raspi3-tutorial`]
 
 ### The Cortex-M team
 
@@ -415,6 +415,7 @@ https://mozilla.logbot.info/rust-embedded
 [`riscv-rust-quickstart`]: https://github.com/riscv-rust/riscv-rust-quickstart
 [`riscv`]: https://github.com/riscv-rust/riscv
 [`rust-embedded-provisioning`]: https://github.com/nastevens/rust-embedded-provisioning
+[`rust-raspi3-tutorial`]: https://github.com/rust-embedded/rust-raspi3-tutorial
 [`spidev`]:https://github.com/rust-embedded/rust-spidev
 [`svd2rust`]: https://github.com/rust-embedded/svd2rust
 [`sysfs-gpio`]: https://github.com/rust-embedded/rust-sysfs-gpio


### PR DESCRIPTION
Moving it to the WG was part of the recently accepted [RFC for a Cortex-A team](https://github.com/rust-embedded/wg/pull/207).

It is currently hosted here: https://github.com/andre-richter/rust-raspi3-tutorial

I think it makes sense to give access to the `cortex-a` and `resources` teams.

As discussed in https://github.com/rust-embedded/wg/pull/227#issuecomment-428287081, there's not much sense in re-approving with a majority, so I would go ahead as soon as I have at least one approval.