### PR TITLE
Update bookshelf URLs to new location

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ a great choice for embedded development.
 **Want to get started with embedded development with Rust?** Check out our
 [embedded Rust book][book] and the rest of our [bookshelf].
 
-[book]: https://rust-embedded.github.io/bookshelf/book
-[bookshelf]: https://rust-embedded.github.io/bookshelf
+[book]: https://docs.rust-embedded.org/book
+[bookshelf]: https://docs.rust-embedded.org
 
 ## Vision
 


### PR DESCRIPTION
Documentation was recently moved to docs.rust-embedded.org and the old
links on this page now result in 404 errors.

Fixes #250