### PR TITLE
notes on highfive

### DIFF
--- a/ops/highfive.md
+++ b/ops/highfive.md
@@ -1,0 +1,16 @@
+# (Using) Highfive
+
+Reference: https://github.com/rust-lang-nursery/highfive
+
+- When you open a PR you will get a welcome comment from `@rust-highfive`
+  assigning a reviewer to your PR.
+
+- The reviewer will be picked at random from the team assigned to the
+  repository.
+
+- You can override the reviewer using `r? @someone` in any comment. If `r?` is
+  used in the PR description you will *not* get a comment from `@rust-highfive`,
+  but `@someone` will still be assigned to the PR.
+
+- If you use `r? @ghost` in the PR description no one will get assigned to
+  review the PR.

--- a/ops/highfive.md
+++ b/ops/highfive.md
@@ -14,3 +14,7 @@ Reference: https://github.com/rust-lang-nursery/highfive
 
 - If you use `r? @ghost` in the PR description no one will get assigned to
   review the PR.
+
+- If you run into what appears to be a bug in highfive please notify the
+  rust-lang/infra team (#infra channel on discord) ASAP -- the highfive logs are
+  kind of short lived.


### PR DESCRIPTION
This PR adds some notes about how to use highfive and a bit of how it works.

For now, highfive has been enabled for the cortex-m repository, but we can send
a PR to rust-lang-nursery/highfive to enable it on other rust-embedded repos.
There's one extra step, which I can do, after the PR lands

Questions:

- Do we want to use highfive on *all* the rust-embedded repos?

- Do we want to do that ^ in one sweep or incrementally? e.g. one team at a time

cc @rust-embedded/all