### PR TITLE
[RFC] lead -> core team

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,25 +109,31 @@ Everyone can contribute to the embedded WG efforts! There are several ways to he
 
 ## Organization
 
-The WG is composed of a lead and several teams whose functions are defined in [RFC
-#136](./rfcs/0136-teams.md). The embedded WG develops and maintains a large set of projects under
-the [rust-embedded] organization. This section lists all the teams and all the projects owned by the
-WG.
+The WG is composed of several teams whose functions are defined in [RFC
+#136](./rfcs/0136-teams.md). The embedded WG develops and maintains a large set
+of projects under the [rust-embedded] organization. This section lists all the
+teams and all the projects owned by the WG.
 
 [rust-embedded]: https://github.com/rust-embedded
 
-### The WG lead
+### The core team
 
-[@japaric] is the current lead of the embedded WG. His functions are:
+The functions of the core team are:
 
-- Representing the WG in meetings where other [Rust teams] participate.
+- Representing the WG in meetings with other [Rust teams].
 - Communicating the needs of the embedded Rust community (e.g. language features, `core` API
   stabilization) to the Rust teams.
 - Giving the casting vote on intra-WG decisions where no [voting majority] can be achieved.
+- Driving and moderating the weekly meetings.
 
 [Rust teams]: https://www.rust-lang.org/en-US/team.html
 [voting majority]: https://github.com/rust-lang-nursery/embedded-wg/blob/master/rfcs/0136-teams.md#voting-majority
 
+#### Members
+
+- [@jamesmunns]
+- [@japaric]
+- [@therealprof]
 
 ### The Cortex-A team
 


### PR DESCRIPTION
## Summary

This RFC proposes that we replace the position of the "lead" with a core team.

## Motivation

I (@japaric) will be busy working on my thesis for the next ~3 months and won't
be able to be as active in the WG as I have been. Instead of having a single
not so active lead for months I propose that we have a small core team that
takes over the functions of the lead.

## Design

The core team will inherit the functions of the lead, namely what's already in
the README:

- Representing the WG in meetings with other Rust teams / WG.

- Communicating the needs of the embedded Rust community to the Rust teams.

- Giving the casting vote on intra-WG decisions where no voting majority can be
  achieved.

- Driving and moderating the weekly meetings.

Additionally, we'll:

- Add the members of the core team to the rust-embedded/core GitHub team (to
  make `cc @rust-embedded/core` work) and give them admin privileges in the
  rust-embedded org (so they can create and modify GH teams).

- Set up an e-mail alias for the core team: core@rust-embedded.org.

## Implementation

I propose that we start the core team with these members:

- [x] @jamesmunns
- [x] @japaric
- [x] @therealprof

(Of course the people above have to accept first.)

I have chosen these people because they have been consistently active in the WG
and have interacted with members of the Rust teams in the past. Also 3 is the
smallest odd number that's not 1.

## Alternatives

As an extension we *could* leave some (all?) decisions on cross cutting issues,
today labeled as `T-all`, to the core team, which would let us make much quicker
decisions but this proposal leaves that up to a different RFC (if we want to do
it at all).

---

r? @rust-embedded/all
