### PR TITLE
temporarily remove japaric from some teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,6 @@ The Cortex-M team develops and maintains the core of the Cortex-M crate ecosyste
 #### Members
 
 - [@adamgreig]
-- [@japaric]
 - [@korken89]
 - [@thejpster]
 - [@therealprof]
@@ -218,7 +217,6 @@ Board Support Crates and drivers.
 #### Members
 
 - [@hannobraun]
-- [@japaric]
 - [@thejpster]
 - [@therealprof]
 - [@ithinuel]
@@ -292,7 +290,6 @@ The resources team develops, maintains and curates resources on embedded Rust.
 - [@adamgreig]
 - [@andre-richter]
 - [@jamesmunns]
-- [@japaric]
 - [@thejpster]
 - [@therealprof]
 
@@ -313,7 +310,6 @@ The tools team maintains and develops core embedded tools.
 #### Members
 
 - [@Emilgardis]
-- [@japaric]
 - [@ryankurte]
 - [@therealprof]
 


### PR DESCRIPTION
As I mentioned in #328 I'll be busier and busier during the next few months so
I'll be temporarily removing myself from some teams. For the next few months
I'll limit my duties to /core, /cortex-r (can't have a one-person team!) and
/ecosystem (when it's formed).

cc @rust-embedded/cortex-m @rust-embedded/embedded-linux @rust-embedded/hal
@rust-embedded/tools

@rust-embedded/triage I will remove myself from the highfive rotation so don't
assign new PRs to me

(This doesn't need voting just notifying the affected teams and a single approval.)
