### PR TITLE
Update Resources Team Membership

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,8 @@ The resources team develops, maintains and curates resources on embedded Rust.
 - [@adamgreig]
 - [@andre-richter]
 - [@jamesmunns]
+- [@korken89]
+- [@ryankurte]
 - [@thejpster]
 - [@therealprof]
 


### PR DESCRIPTION
I noticed that @rust-embedded/resources includes a larger list of people than the README. I can't remember if this was already decided, and the README just wasn't updated?

If this was already decided for @korken89 and @ryankurte, I don't think we need a full team vote. Could either of you please provide background?