### PR TITLE
Remove linux-embedded-hal duplicat team assignment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,6 @@ Board Support Crates and drivers.
 Projects maintained by the HAL team.
 
 - [`embedded-hal`]
-- [`linux-embedded-hal`]
 
 ### The MSP430 team
 


### PR DESCRIPTION
Let me know if the linux-embedded-hal should be removed from the embbeded linux team instead of the HAL team.