### PR TITLE
Add "Hibernating" section to README, add myself

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,6 @@ Board Support Crates and drivers.
 
 #### Members
 
-- [@hannobraun]
 - [@thejpster]
 - [@therealprof]
 - [@ithinuel]
@@ -362,6 +361,12 @@ most of them are members of one of the teams listed above.
 - [@jcsoo]
 - [@pftbest]
 - [@thejpster]
+
+### Hibernating
+
+The following members have put themselves into hibernation the hibernation state, due to being absent or busy for an extended amount of time. See [ops/hibernating.md](https://github.com/rust-embedded/wg/blob/master/ops/hibernating.md).
+
+- [@hannobraun]
 
 ### Contact
 


### PR DESCRIPTION
I haven't been very active in the working group for a long while now, and I don't see this changing much going forward. For this reason, I'm putting myself into the hibernation state.

I'm not leaving the community though! I'm still involved in [nrf-rs](https://github.com/nrf-rs), [lpc-rs](https://github.com/lpc-rs), and my various other open source projects. I also intend to still keep up with many of the WG repositories, so the main difference is going to be that I'll no longer feel bad for not doing any actual work :-)

cc @rust-embedded/hal