### PR TITLE
laanwj joining RISC-V team

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ https://mozilla.logbot.info/rust-embedded
 [@japaric]: https://github.com/japaric
 [@jcsoo]: https://github.com/jcsoo
 [@korken89]: https://github.com/korken89
+[@laanwj]: https://github.com/laanwj
 [@mathk]: https://github.com/mathk
 [@nastevens]: https://github.com/nastevens
 [@nerdyvaishali]: https://github.com/nerdyvaishali

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ The RISCV team develops and maintains the core of the RISCV crate ecosystem.
 - [@danc86]
 - [@dvc94ch]
 - [@Disasm]
+- [@laanwj]
 
 #### Projects
 


### PR DESCRIPTION
Hello, I'd like to join the Rust RISC-V team!

I have various activity around RISC-V and Rust the last year:

- Contributed peripheral descriptions to [k210-pac](https://github.com/riscv-rust/k210-pac), and UART serial for [k210-hal](https://github.com/riscv-rust/k210-hal/)
- Wrote some [embedded demos in Rust](https://github.com/laanwj/k210-sdk-stuff) for the Maix Go Board, porting part of the Kendryte C SDK to Rust on the way
- Contributed to [rvsim](https://github.com/stephank/rvsim), a RV32G simulator in Rust
- Created [rust-riscv-disasm](https://github.com/laanwj/rust-riscv-disasm), a RISC-V disassembler in Rust

My primary interest in RISC-V is as a secure future architecture for bitcoin things. However, I'm also interested in advancing the state of Rust on RISC-V in general. I'm *relatively* new to Rust but really like the language and see it as the spiritual successor to C++.

Besides the MaixGo I have a SiFive Unleashed board and HiFive1 (both rev a and b) for testing on actual hardware.

@Disasm 