### PR TITLE
Increase the newsletter visibility, fix Matrix room link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,13 @@ a great choice for embedded development.
 **Want to get started with embedded development with Rust?** Check out our
 [embedded Rust book][book] and the rest of our [bookshelf].
 
+Want to stay up-to-date with community progress? Check out our [newsletter].
+
 Join the discussion on Matrix! [#rust-embedded:matrix.org](https://matrix.to/#/!BHcierreUuwCMxVqOf:matrix.org)
 
 [book]: https://docs.rust-embedded.org/book
 [bookshelf]: https://docs.rust-embedded.org
+[newsletter]: https://rust-embedded.github.io/blog/
 
 ## Vision
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ a great choice for embedded development.
 
 Want to stay up-to-date with community progress? Check out our [newsletter].
 
-Join the discussion on Matrix! [#rust-embedded:matrix.org](https://matrix.to/#/!BHcierreUuwCMxVqOf:matrix.org)
+Join the discussion on Matrix! [#rust-embedded:matrix.org](https://matrix.to/#/#rust-embedded:matrix.org)
 
 [book]: https://docs.rust-embedded.org/book
 [bookshelf]: https://docs.rust-embedded.org


### PR DESCRIPTION
For some reason, `https://matrix.to/#/#rust-embedded:matrix.org` link leads to the page with more client options.