### PR TITLE
Transfer smoltcp and rust-manged into WG under Tools team

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,8 @@ Projects maintained by the tools team
 - [`cargo-binutils`]
 - [`cross`]
 - [`itm`]
+- [`rust-managed`]
+- [`smoltcp`]
 - [`svd-parser`]
 - [`svd2rust`]
 
@@ -469,7 +471,9 @@ Our Matrix room is logged by [logbot] on the bridged IRC channel, and you can fi
 [`riscv-rust-quickstart`]: https://github.com/riscv-rust/riscv-rust-quickstart
 [`riscv`]: https://github.com/rust-embedded/riscv
 [`rust-embedded-provisioning`]: https://github.com/rust-embedded/rust-embedded-provisioning
+[`rust-managed`]: https://github.com/rust-embedded/rust-managed
 [`rust-raspi3-OS-tutorials`]: https://github.com/rust-embedded/rust-raspi3-OS-tutorials
+[`smoltcp`]: https://github.com/rust-embedded/smoltcp
 [`spidev`]:https://github.com/rust-embedded/rust-spidev
 [`svd2rust`]: https://github.com/rust-embedded/svd2rust
 [`svd-parser`]: https://github.com/rust-embedded/svd


### PR DESCRIPTION
This PR would transfer [smoltcp](https://github.com/smoltcp-rs/smoltcp) and its dependency [rust-managed](https://github.com/smoltcp-rs/rust-managed) into the WG under the Tools team.

From their READMEs:
> _smoltcp_ is a standalone, event-driven TCP/IP stack that is designed for bare-metal, real-time systems

> _managed_ is a library that provides a way to logically own objects, whether or not heap allocation is available

smoltcp is looking for a new home and the current maintainers are happy to transfer it to the rust-embedded organisation, including push access to crates.io. The idea of transferring the crates was discussed in the weekly meetings on 2020-02-18 and 2020-02-25, with this PR being the outcome.

At the moment the Tools team seems the best fit for these libraries, but if/when #266 goes ahead it's anticipated we'd move these repositories to be under that new libs team. Right now none of the Tools team are necessarily very experienced with smoltcp maintenance; the expectation is that existing contributors will be able to continue working on smoltcp, while having it under the WG will help encourage new contributors and ensure continuity for this useful embedded crate.

Additionally there are some worries that having smoltcp under rust-embedded would be seen as blessing a single implementation to the detriment of other embedded TCP/IP stacks; to address this we intend to clearly note in the README that while smoltcp is maintained by the rust-embedded organisation, we don't intend for it to be the only embedded TCP/IP stack and encourage experimentation with alternatives. If multiple embedded TCP/IP stacks become widespread, we could seek to have abstraction/portability libraries in the WG and move the actual implementations to their own organisations.

This PR needs to be approved by the Tools team:

* [x] @adamgreig
* [ ] @burrbull
* [ ] @Disasm
* [x] @Emilgardis
* [ ] @reitermarkus
* [x] @ryankurte
* [x] @therealprof