### PR TITLE
Remove @Disasm from Tools and Triage teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,6 @@ The tools team maintains and develops core embedded tools.
 
 - [@adamgreig]
 - [@burrbull]
-- [@Disasm]
 - [@Emilgardis]
 - [@reitermarkus]
 - [@ryankurte]
@@ -346,7 +345,6 @@ The triage team is charge of keeping PR queues moving; they ensure no PR is left
 
 #### Members
 
-- [@Disasm]
 - [@mathk]
 
 ### The IRR 2018 team


### PR DESCRIPTION
I have not been active in this teams for a long time, so I decided to remove myself to slightly improve voting process.