### PR TITLE
Step down from the core team and nominate adamgreig

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The functions of the core team are:
 
 #### Members
 
-- [@jamesmunns]
+- [@adamgreig]
 - [@japaric]
 - [@therealprof]
 


### PR DESCRIPTION
So, we don't generally have a process for changing of the guard for the core team, but I think this is a healthy time to blaze some trails!

Due to scheduling and availability issues around [Ferrous Systems](https://ferrous-systems.com)' work on [OxidizeConf](https://oxidizeconf.com/) and [Sealed Rust](https://ferrous-systems.com/blog/sealed-rust-the-pitch/), I see myself being more and more busy over the coming months. For this reason, I plan to step down from the Core team, but remain on the Resources team.

Because it is important to have three people on the core team (to avoid deadlocked decisions), I'd also like to simultaneously nominate @adamgreig to replace me. In general, I'll plan on stepping down once a replacement is approved by @rust-embedded/all, whoever it is, but I think Adam would be an excellent choice, as one of the longest active members, a core maintainer of stm32-rs (probably the most active family of chip support groups in Rust), and an overall helpful and supportive member of the WG team!

I'll still be around to help out, but I think it's healthy for the embedded-wg to have a change of hands occasionally! Thanks to everyone who has helped make the working group what it is today :)