### PR TITLE
Add eldruin to embedded linux team

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ The embedded Linux team develops and maintains the core of the embedded Linux cr
 
 #### Members
 
+- [@eldruin]
 - [@nastevens]
 - [@posborne]
 - [@ryankurte]


### PR DESCRIPTION
I was approached by @ryankurte about joining the embedded linux team and I would be happy to.
So far I have contributed to `rust-i2cdev` and `linux-embedded-hal` adding support for transactional I2C among other smaller fixes. See:
- https://github.com/rust-embedded/rust-i2cdev/pull/51
- https://github.com/rust-embedded/linux-embedded-hal/pull/26

Other than that I guess everyone here knows me already.
Nevertheless, please feel free to raise any concerns.