### PR TITLE
Mention support of RP2040 microcontrollers

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ The list below is not exhaustive and will be updated as device support increases
 - [lpc-rs](https://github.com/lpc-rs): NXP LPC microcontrollers
 - [imxrt-rs](https://github.com/imxrt-rs): NXP i.MX RT microcontrollers
 - [esp-rs](https://github.com/esp-rs): Espressif Systems microcontrollers
+- [rp-rs](https://github.com/rp-rs): Raspberry Silicon RP2040 microcontroller 
 
 ### [`embedded-hal`]
 

--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ The list below is not exhaustive and will be updated as device support increases
 - [lpc-rs](https://github.com/lpc-rs): NXP LPC microcontrollers
 - [imxrt-rs](https://github.com/imxrt-rs): NXP i.MX RT microcontrollers
 - [esp-rs](https://github.com/esp-rs): Espressif Systems microcontrollers
-- [rp-rs](https://github.com/rp-rs): Raspberry Silicon RP2040 microcontroller 
+- [rp-rs](https://github.com/rp-rs): Raspberry Pi microcontrollers including the RP2040
 
 ### [`embedded-hal`]
 


### PR DESCRIPTION
While it's still a work in progress, the community at [rp-rs](https://github.com/rp-rs) has built usable Rust crates for the RP2040 microcontroller, which should be mentioned in the list of device specific communities.