### PR TITLE
Add initial draft of social media ops

### DIFF
--- a/ops/social-media.md
+++ b/ops/social-media.md
@@ -1,0 +1,66 @@
+# Social Media Guide
+
+The [Resources Team] currently maintains three official social media accounts:
+
+* [Twitter: @rustembedded](https://twitter.com/rustembedded)
+    * Maintained by [@jamesmunns]
+* [Cohost: @rustembedded](https://cohost.org/rustembedded)
+    * Maintained by [@adamgreig] and [@jamesmunns]
+* [Mastodon: @rustembedded@hachyderm.io]
+    * Maintained by [@adamgreig]
+
+[Resources Team]: https://github.com/rust-embedded/wg#the-resources-team
+[@jamesmunns]: https://github.com/jamesmunns
+[@adamgreig]: https://github.com/adamgreig
+[Mastodon: @rustembedded@hachyderm.io]: https://hachyderm.io/@rustembedded
+
+## Operational Guide
+
+The purpose of the social media accounts is to spread awareness of topics related to embedded rust.
+
+Social Media accounts will typically:
+
+1. Post about specific announcements from the working group, e.g. to tell people about some major new release, a breaking change, etc
+2. Post WG blog posts
+3. Repost/share people offering and seeking jobs, with reasonable rate-limiting (e.g. one post/week per person/group), see below for more info
+4. Repost/share people's posts tagged/mentioning embedded rust, with reasonable rate-limiting (e.g. one post/week per person/group)
+5. Repost/share other major Rust related posts, e.g. from the official Rust account
+
+In general, we ask that all social media account maintainers use their best judgement to uphold the [Rust Code of Conduct], and operate the account in a way that is both generally appropriate in representing the Rust Embedded Working Group, as well as appropriate for the social media community and norms of that particular site.
+
+Rust Code of Conduct: https://www.rust-lang.org/policies/code-of-conduct
+
+## How to Share
+
+Each platform has different mechanisms/norms for sharing content, or marking a post as "wanting to be reposted".
+
+Social media accounts should periodically remind followers how to do this, and include it in the profile, if possible.
+
+### For Twitter
+
+On twitter, we ask that people "@ mention" the rustembedded account, e.g. include "@rustembedded" in a tweet.
+
+The twitter account will directly be notified by these mentions.
+
+### For Cohost
+
+On Cohost, we ask that people include the [#rustembedded](https://cohost.org/rc/tagged/rustembedded) tag on their posts.
+
+The cohost account follows this tag, and pulls posts from the stream.
+
+### For Mastodon
+
+TODO: James doesn't know how this works
+
+## Job Postings
+
+We will, at the account maintainer's discretion, repost "looking for work" or "job offer" posts. Generally with the twitter account, we've asked that:
+
+* For Job offers, the job offer must:
+    * Be public (e.g. a tweet, blog post, or on a public job posting board)
+    * Mention Rust (may be one of multiple mentioned languages, but should be relevant to the posting)
+    * Mention Embedded
+* For "looking for work" posts, the user must:
+    * Be an individual or business directly looking for work (e.g. not a staffing agency)
+    * Mention Rust
+    * Mention Embedded


### PR DESCRIPTION
This is a first draft of a general "social media ops" outline.

CC #647.

CC @adamgreig, @thejpster, @mygnu, I could use a hand with "how to mastodon"!