### PR TITLE
Update cortex-a team crates: drop cortex-a and register-rs, add aarch64-cpu

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,7 @@ The Cortex-A team develops and maintains the core of the Cortex-A crate ecosyste
 
 Projects maintained by this team.
 
-- [`cortex-a`]
-- [`register-rs`]
+- [`aarch64-cpu`]
 - [`rust-raspberrypi-OS-tutorials`]
 
 ### The Cortex-M team


### PR DESCRIPTION
cortex-a and register-rs are both deprecated; cortex-a was replaced by aarch64-cpu while register-rs is replaced by tock-registers (not part of the wg).