### PR TITLE
Leave tools team, join HAL, libs and embedded Linux teams.

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,6 @@ embedded targets themselves.
 - [@adamgreig]
 - [@burrbull]
 - [@Emilgardis]
-- [@reitermarkus]
 - [@ryankurte]
 - [@therealprof]
 


### PR DESCRIPTION
I initially joined the tools team to maintain `cross`, which isn't in this org anymore and I am not really using the other tools. I mostly use `heapless`, `embedded-hal`, `critical-section` and the various embedded Linux crates these days, and it makes sense to maintain the crates I actually use.
