### PR TITLE
Add @berkus to cortex-a team

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ The Cortex-A team develops and maintains the core of the Cortex-A crate ecosyste
 
 - [@raw-bin]
 - [@nchong-at-aws]
+- [@berkus]
 
 #### Projects
 
@@ -452,6 +453,7 @@ Our Matrix room is logged by on the bridged IRC channel, and you can find the lo
 [@newAM]: https://github.com/newAM
 [@hdoordt]: https://github.com/hdoordt
 [@rmsyn]: https://github.com/rmsyn
+[@berkus]: https://github.com/berkus
 
 [@rustembedded twitter]: https://twitter.com/rustembedded
 [Awesome embedded Rust]: https://github.com/rust-embedded/awesome-embedded-rust


### PR DESCRIPTION
After some discussions with @adamgreig and @nchong-at-aws, also supported by @andre-richter.

See also https://github.com/rust-embedded/aarch64-cpu/issues/29 for more context.

Part of my comms with Nathan, for transparency:

- I'm a long time committer to aarch64-cpu crate, 

<img width="802" alt="image" src="https://github.com/user-attachments/assets/16c0a2ea-e3ef-4cf0-91bc-32121ba331a0">

- I would like to set up an automated publishing pipeline, review some pending PR's and perhaps go through some changes that folks introduced in the independent forks.

- I use this crate myself all the time, it's part of my OSdev project.