### PR TITLE
add Bart Massey to Arm team

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ and microcontrollers, including Cortex-A, Cortex-R, and Cortex-M.
 #### Members
 
 - [@adamgreig]
+- [@bartmassey]
 - [@berkus]
 - [@jonathanpallant]
 - [@nchong-at-aws]


### PR DESCRIPTION
I would be honored to join the Arm team; I would like to help with AArch64 Rust targets, among other things.

JP adds:

* [x] [@adamgreig](https://github.com/adamgreig)
* [x] [@berkus](https://github.com/berkus)
* [x] [@jonathanpallant](https://github.com/jonathanpallant)
* [ ] [@nchong-at-aws](https://github.com/nchong-at-aws)
* [x] [@newAM](https://github.com/newAM)
* [ ] [@raw-bin](https://github.com/raw-bin)
* [x] [@robamu](https://github.com/robamu)
* [x] [@thalesfragoso](https://github.com/thalesfragoso)
* [ ] [@therealprof](https://github.com/therealprof)
* [ ] [@ithinuel](https://github.com/ithinuel)