### PR TITLE
Add Zeeshan Ali Khan to libs team

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ The libs team manages library code that is not architecture-specific.
 - [@dirbaio]
 - [@newAM]
 - [@reitermarkus]
+- [@zeenix]
 
 #### Projects
 


### PR DESCRIPTION
c&ping the rationale from #857:

You may have noticed that I've been pushing for a heapless release on and off for the last few months now, mainly on the [matrix channel](https://matrix.to/#/#rust-embedded:matrix.org). 😆 I managed to convince folks to give it a bit of time and [helped prep the 0.9.0](https://github.com/rust-embedded/heapless/pull/556) and was very glad when it happened. 🥳 Unfortunately it had to be yanked because of a breakage but 0.9.1 hasn't happened for months, mainly due to maintainers not having the time^1 to review [the remaining PR that's tagged for 0.9.1](https://github.com/rust-embedded/heapless/pull/571). So we're still stuck with no release for more than 2 years and a lot of fixes and improvements remaining in git.

It was suggested to me that if I want to really change the maintenance status of heapless, I should volunteer to join the team. While I'm not a huge contributor to heapless, I've contributed [a few PRs](https://github.com/rust-embedded/heapless/pulls?q=author%3Azeenix) and (as I wrote already) helped with getting 0.9.0 out. If it helps, I'm the creator and maintainer of zbus, a crate with over 25 million unique downloads on crates.io alone and maintain a few other crates too.

---

^1 I'm not blaming anyone. I know very well, that one can get busy with life and work-work.

Fixes #857.