### PR TITLE
Add Sosthène Guédon to the libs team

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ The libs team manages library code that is not architecture-specific.
 - [@newAM]
 - [@reitermarkus]
 - [@zeenix]
+- [@sgued]
 
 #### Projects
 


### PR DESCRIPTION
The motivation is similar to https://github.com/rust-embedded/wg/pull/858

Heapless is under-maintained. It hasn't had a release in a while. There was a 0.9.0 release but I was yanked after I noticed that the breakage and required downstream changes were much more important than intended.
I made the PR that fixed the breakage and prepare 0.9.1 release but this was never released. I've already kept an eye and even reviewed some incoming PRs to make sure 0.9.1 could be released as soon as a maintainer had the time. @zeenix joined to help maintain and release a 0.9.1 and suggested I do too. I think I could also be helpful in improving the maintenance of the project.

More than a year ago I contributed to `heapless` the `View` types, hoping they could be released in minor release. Retrospectively I should have gotten involved in the maintenance then if I wanted this to happen. But it's never too late to improve things for the future.

You can see my contributions here: https://github.com/rust-embedded/heapless/issues?q=author%3Asosthene-nitrokey (its not the same account as this one but if I become a maintainer I might want to contribute also outside of work context).
As part of my job I also maintain some other embedded-related crates (most notably `heapless-bytes`, `littlefs2`, and historically `serde-byte-array`).

---
- [ ] @dirbaio
- [ ] @newAM
- [ ] @reitermarkus
- [ ] @zeenix
---