### PR TITLE
Add DorotaC to the RISC-V team

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ The RISC-V team develops and maintains the core of the RISC-V crate ecosystem.
 - [@MabezDev]
 - [@jessebraham]
 - [@rmsyn]
+- [@dcz-self]
 
 #### Projects
 


### PR DESCRIPTION
I'm nominating myself to the RISC-V team.

The immediate reason is that I want to [fix](https://github.com/riscv-rust/gd32vf103xx-hal/pull/63) and release the [gd32vf103xx-hal](https://github.com/riscv-rust/gd32vf103xx-hal/) crate, rather than fork it and let changes fall into obscurity. The crate seems to be unmaintained for 2 years, with no release for 4 years. I [was recommended](https://github.com/riscv-rust/gd32vf103xx-hal/issues/62#issuecomment-3225243359) to join the RISC-V team in order to get merge rights.

I'm also going to be completely satisfied if this application gets rejected in favor of adding me to the dead crate's maintainers directly. I intend to bring it to HAL v1.0 and stay on top of MRs.

Either way, the [project](https://codeberg.org/dcz/busbang/src/branch/master/bb-longan) I'm working on also requires fixes to the USB driver, so I'd use my team powers to take care of that too.