### PR TITLE
updated title of Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# The Rust Code of Conduct
+# The Rust Embedded Working Group Code of Conduct
 
 ## Conduct
 


### PR DESCRIPTION
CoC title now reflects that this is the REWG CoC, not just the Rust one.